### PR TITLE
Fix item marker logic for AP items

### DIFF
--- a/rust/maprando-game/src/lib.rs
+++ b/rust/maprando-game/src/lib.rs
@@ -189,7 +189,9 @@ impl Item {
             Item::ETank,
             Item::ReserveTank,
             Item::Nothing,
-            Item::ArchipelagoUsefulProgItem,
+            Item::ArchipelagoItem,
+            Item::ArchipelagoUsefulItem,
+            Item::ArchipelagoProgItem,
         ]
         .contains(&self)
     }

--- a/rust/maprando/src/patch/map_tiles.rs
+++ b/rust/maprando/src/patch/map_tiles.rs
@@ -1257,9 +1257,9 @@ pub fn get_item_interior(item: Item, settings: &RandomizerSettings) -> MapTileIn
             }
         }
         ItemMarkers::ThreeTiered => {
-            if item.is_unique() {
+            if item.is_unique() || item == Item::ArchipelagoProgItem {
                 MapTileInterior::MajorItem
-            } else if item != Item::Missile && item != Item::Nothing && item != Item::ArchipelagoItem && item != Item::ArchipelagoUsefulItem{
+            } else if item != Item::Missile && item != Item::Nothing && item != Item::ArchipelagoItem {
                 MapTileInterior::MediumItem
             } else {
                 MapTileInterior::Item


### PR DESCRIPTION
Notably fixes all AP items being marked as major items, except UsefulProg which was a small dot
UsefulProg also failed the assertion for 4-tiered markers

~~Didn't test as I've never done Rust and idk how to build the lib~~
I tested it and it seemed to work correctly