### PR TITLE
Ensure map used for common map seeds is the same

### DIFF
--- a/rust/maprando/src/lib.rs
+++ b/rust/maprando/src/lib.rs
@@ -290,8 +290,9 @@ fn randomize_ap(
     );
     let map_layout = settings.map_layout.clone();
     let max_attempts = 2000;
-    let max_attempts_per_map = if settings.start_location_settings.mode == StartLocationMode::Random
-    {
+    let max_attempts_per_map = if map_seed_ap.is_some() {
+        max_attempts
+    } else if settings.start_location_settings.mode == StartLocationMode::Random {
         10
     } else {
         1


### PR DESCRIPTION
By default, upstream Map Rando only tries a specific map for one or 10 generations, depending on settings.
Using the same map seed only guarantees that you'll be iterating over the same set of maps, instead of always getting one specific map. This meant that AP players using the `common_map` option could end up with a different map, depending on how many attempts their individual generations took.

This adds a specific case for generations where `map_seed_ap` is set by setting `max_attempts_per_map` equal to `max_attempts`, to ensure the map will not change, and therefore a same value of `map_seed_map` will guarantee the same map.