### PR TITLE
Support ROMless AP Patch generation

### DIFF
--- a/rust/maprando/src/customize_seed.rs
+++ b/rust/maprando/src/customize_seed.rs
@@ -243,12 +243,12 @@ pub fn customize_seed_ap(
         return HttpResponse::BadRequest().body(InvalidRomTemplate {}.render().unwrap());
     }
 */
+    let ultra_low_qol = if settings.is_some() {
+        settings.as_ref().unwrap().other_settings.ultra_low_qol
+    } else {
+        false
+    };
     let customize_settings = CustomizeSettings {
-        let ultra_low_qol = if settings.is_some() {
-            settings.as_ref().unwrap().other_settings.ultra_low_qol
-        } else {
-            false
-        };
         samus_sprite: if ultra_low_qol
             && req.samus_sprite == "samus_vanilla"
             && req.vanilla_screw_attack_animation
@@ -326,13 +326,9 @@ pub fn customize_seed_ap(
 
     if settings.is_some()
         && let Some(json) = randomization
-        && let Ok(mut randomization) = serde_json::from_str(&json)
+        && let Ok(mut randomization) = serde_json::from_str<Randomization>(&json)
     {
         info!("Patching ROM");
-        randomization.item_placement = new_item_placement;
-        if new_item_spoiler_infos.is_some() {
-            randomization.essential_spoiler_data.item_spoiler_info = new_item_spoiler_infos.unwrap();
-        }
         upgrade_randomization(&mut randomization);
         match make_rom(
             &rom,

--- a/rust/maprando/src/customize_seed.rs
+++ b/rust/maprando/src/customize_seed.rs
@@ -180,10 +180,7 @@ pub fn customize_seed_ap(
     req: CustomizeRequest,
     app_data: AppData,
     settings: Option<RandomizerSettings>,
-    randomization: Option<Randomization>,
-    ultra_low_qol: bool,
-    new_item_placement: Vec<Item>,
-    new_item_spoiler_infos: Option<Vec<EssentialItemSpoilerInfo>>
+    randomization: Option<String>,
 ) -> Vec<u8> {
     info!("customize_seed_ap");
     //let seed_name = &info.0;
@@ -247,6 +244,11 @@ pub fn customize_seed_ap(
     }
 */
     let customize_settings = CustomizeSettings {
+        let ultra_low_qol = if settings.is_some() {
+            settings.as_ref().unwrap().other_settings.ultra_low_qol
+        } else {
+            false
+        };
         samus_sprite: if ultra_low_qol
             && req.samus_sprite == "samus_vanilla"
             && req.vanilla_screw_attack_animation
@@ -323,7 +325,8 @@ pub fn customize_seed_ap(
     };
 
     if settings.is_some()
-        && let Some(mut randomization) = randomization
+        && let Some(json) = randomization
+        && let Ok(mut randomization) = serde_json::from_str(&json)
     {
         info!("Patching ROM");
         randomization.item_placement = new_item_placement;

--- a/rust/maprando/src/customize_seed.rs
+++ b/rust/maprando/src/customize_seed.rs
@@ -326,7 +326,7 @@ pub fn customize_seed_ap(
 
     if settings.is_some()
         && let Some(json) = randomization
-        && let Ok(mut randomization) = serde_json::from_str<Randomization>(&json)
+        && let Ok(mut randomization) = serde_json::from_str::<Randomization>(&json)
     {
         info!("Patching ROM");
         upgrade_randomization(&mut randomization);

--- a/rust/maprando/src/lib.rs
+++ b/rust/maprando/src/lib.rs
@@ -491,6 +491,17 @@ fn randomize_ap(
 */
 }
 
+#[pyfunction]
+fn randomization_to_json(randomization: &Randomization) -> Option<String> {
+    return match serde_json::to_string(&randomization) {
+        Ok(s) => Some(s),
+        _ => {
+            error!("Couldn't convert Randomization to JSON string");
+            None
+        }
+    }
+}
+
 #[pymodule]
 #[pyo3(name = "pysmmaprando")]
 fn pysmmaprando(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -505,5 +516,6 @@ fn pysmmaprando(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(validate_settings_ap, m)?)?;
     m.add_function(wrap_pyfunction!(randomize_ap, m)?)?;
     m.add_function(wrap_pyfunction!(customize_seed_ap, m)?)?;
+    m.add_function(wrap_pyfunction!(randomization_to_json, m)?)?;
     Ok(())
 }

--- a/rust/maprando/src/lib.rs
+++ b/rust/maprando/src/lib.rs
@@ -198,7 +198,7 @@ pub struct AttemptOutput {
         map_seed: usize,
         door_randomization_seed: usize,
         item_placement_seed: usize,
-        #[pyo3(get)]
+        #[pyo3(get, set)]
         randomization: Randomization,
         #[pyo3(get)]
         spoiler_log: SpoilerLog,

--- a/rust/maprando/src/randomize.rs
+++ b/rust/maprando/src/randomize.rs
@@ -321,7 +321,7 @@ pub struct Randomization {
     pub map: Map,
     pub toilet_intersections: Vec<RoomGeometryRoomIdx>,
     pub locked_doors: Vec<LockedDoor>,
-    #[pyo3(get)]
+    #[pyo3(get, set)]
     pub item_placement: Vec<Item>,
     pub start_location: StartLocation,
     pub escape_time_seconds: f32,


### PR DESCRIPTION
Changes `customize_seed_ap` to use a JSON string taken from an APProcedurePatch rather than a Randomization object
Also makes a few fields get/settable to modify some data in python and have less arguments in the function